### PR TITLE
Replace access tokens for new server side token

### DIFF
--- a/config/ey_services_config_deploy.yml
+++ b/config/ey_services_config_deploy.yml
@@ -174,4 +174,4 @@ environments:
     #precompile_unchanged_assets: true
 
 rollbar:
-  ROLLBAR_ACCESS_TOKEN: fc316ac1f7404dc28af26d5baed1416c
+  ROLLBAR_ACCESS_TOKEN: 2fd2af18dfe9430f9077dd4c95f4610b

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -12,7 +12,7 @@ Rollbar.configure do |config|
     # feel free to use this access token for testing out api calls and seeing what shows up
     # in the demo.
     # please don't abuse this token. we'll just have to disable it.
-    config.access_token = 'fc316ac1f7404dc28af26d5baed1416c'
+    config.access_token = '2fd2af18dfe9430f9077dd4c95f4610b'
   end
 
   # Without configuration, Rollbar is enabled in all environments.


### PR DESCRIPTION
The change here is to replace a deleted access token, so that we can continue sending data to the demo app.